### PR TITLE
fix init-debug.log path

### DIFF
--- a/zdfs.go
+++ b/zdfs.go
@@ -73,7 +73,7 @@ func overlaybdConfPath(dir string) string {
 }
 
 func overlaybdInitDebuglogPath(dir string) string {
-	return filepath.Join(dir, zdfsMetaDir, "init-debug.log")
+	return filepath.Join(dir, "block", "init-debug.log")
 }
 
 func isOverlaybdLayer(dir string) (bool, error) {


### PR DESCRIPTION
fix path of init-debug.log, for snapshotter get result from "block/init-debug.log"